### PR TITLE
chore: pin GitHub Actions to SHA for supply chain security

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -25,14 +25,14 @@ jobs:
     name: Build app and test runner
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - run: ./scripts/ci-select-xcode.sh
       - name: Install SentryCli
         run: brew install getsentry/tools/sentry-cli
       - run: git apply ./scripts/set-device-tests-environment.patch
       - name: Cache iOS-Swift App and dSYM build products
         id: ios-swift-cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
         with:
           path: |
             DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app.dSYM
@@ -40,7 +40,7 @@ jobs:
           key: ios-swift-for-ui-testing-cache-key-${{ hashFiles('Samples/iOS-Swift/iOS-Swift/**') }}
       - name: Cache iOS-Swift UI Test Runner App build product
         id: ios-swift-benchmark-runner-cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
         with:
           path: |
             DerivedData/Build/Products/Debug-iphoneos/PerformanceBenchmarks-Runner.app
@@ -67,7 +67,7 @@ jobs:
         run: |
           sentry-cli --auth-token ${{ secrets.SENTRY_AUTH_TOKEN }} upload-dif --org sentry-sdks --project sentry-cocoa DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app.dSYM
       - name: Archiving DerivedData
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5  # v3
         with:
           name: DerivedData-Xcode
           path: |
@@ -83,8 +83,8 @@ jobs:
       matrix:
         suite: ['High-end device', 'Mid-range device', 'Low-end device']
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3
         with:
           name: DerivedData-Xcode
       - run: npm install -g saucectl@0.107.2
@@ -99,9 +99,9 @@ jobs:
     runs-on: macos-12
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - run: ./scripts/ci-select-xcode.sh
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
         id: app-plain-cache
         with:
           path: Tests/Perf/test-app-plain.ipa

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -128,7 +128,7 @@ jobs:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_USERNAME: ${{ secrets.MATCH_USERNAME }}
       - name: Collect app metrics
-        uses: getsentry/action-app-sdk-overhead-metrics@v1
+        uses: getsentry/action-app-sdk-overhead-metrics@c9eca50e02d180ee07a02952c062b2f3f545f735  # v1
         with:
           config: Tests/Perf/metrics-test.yml
           sauce-user: ${{ secrets.SAUCE_USERNAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     name: Release Build of iOS Swift
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - run: ./scripts/ci-select-xcode.sh
 
       - name: Run Fastlane
@@ -49,7 +49,7 @@ jobs:
           - iOS13-Swift
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - run: ./scripts/ci-select-xcode.sh
 
       # Disable code signing. We just want to make sure these compile.
@@ -66,7 +66,7 @@ jobs:
     name: Sample watchOS
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - run: ./scripts/ci-select-xcode.sh
       - run: make build-for-watchos
 
@@ -83,14 +83,14 @@ jobs:
     name: Build & Validate XCFramework
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - run: make build-xcframework
         shell: sh
       - run: make build-xcframework-sample
         shell: sh
 
       - name: Archiving XCFramework.zip
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5  # v3
         with:
           name: ${{ github.sha }}
           if-no-files-found: error
@@ -102,7 +102,7 @@ jobs:
     name: Build & Validate Framework
     runs-on: macos-11
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - run: ./scripts/ci-select-xcode.sh 12.5.1
       - run: make build-framework
         shell: sh
@@ -110,7 +110,7 @@ jobs:
         shell: sh
 
       - name: Archiving Framework.zip
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5  # v3
         with:
           name: ${{ github.sha }}
           if-no-files-found: error
@@ -124,7 +124,7 @@ jobs:
     name: Validate Swift Package Manager
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - name: Set SPM revision to current git commit
         run: >-
           if [[ "${{ github.event.pull_request.head.sha }}" != "" ]]; then
@@ -141,7 +141,7 @@ jobs:
     name: Validate Swift Package Manager Dynamic
     runs-on: macos-11
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - name: Set SPM revision to current git commit
         run: >-
           if [[ "${{ github.event.pull_request.head.sha }}" != "" ]]; then
@@ -158,6 +158,6 @@ jobs:
     name: Build with Swift
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - run: swift build
         shell: sh

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@18fe527fa8b29f134bb91f32f1a5dc5abb15ed7f # pin@v2

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -15,7 +15,7 @@ jobs:
     name: Format Code
     runs-on: macos-11
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - name: Install Clang-Format
         run: brew install clang-format
       - name: Format Code

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: macos-11
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
         with:
           repository: 'Alamofire/Alamofire'
           ref: 'f82c23a8a7ef8dc1a49a8bfc6a96883e79121864'
@@ -78,7 +78,7 @@ jobs:
     env:
       DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
         with:
           repository: 'home-assistant/iOS'
           ref: '6d6606aed63a778c5a2bd64f8981823433a7f2fa'
@@ -100,14 +100,14 @@ jobs:
       - name: Download and Apply Patch
         run: ./apply-patch.sh "${{ github.event.pull_request.head.sha }}" "${{ github.sha }}" add-sentry-to-homekit
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
         name: 'Cache: Gems'
         id: cache_gems
         with:
           path: vendor/bundle
           key: home-assistant-integration-gems-${{ runner.os }}-${{ env.ImageVersion }}-${{ env.DEVELOPER_DIR }}-${{ hashFiles('**/Gemfile.lock') }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
         name: 'Cache: Pods'
         id: cache_pods
         if: steps.cache_gems.outputs.cache-hit == 'true'
@@ -145,7 +145,7 @@ jobs:
     runs-on: macos-12
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
         with:
           repository: 'videolan/vlc-ios'
           ref: '5d2b5505edc3387cad43deca14c0bd0b19e3f133'
@@ -167,7 +167,7 @@ jobs:
       - name: Download and Apply Patch
         run: ./apply-patch.sh "${{ github.event.pull_request.head.sha }}" "${{ github.sha }}" add-sentry-to-vlc
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
         name: 'Cache: Pods'
         id: cache-pods
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
     name: Swift Lint
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - name: Run SwiftLint
         run: swiftlint
 
@@ -35,7 +35,7 @@ jobs:
     name: Xcode Analyze
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - run: ./scripts/ci-select-xcode.sh
       - run: make analyze
 
@@ -47,7 +47,7 @@ jobs:
         platform: ['ios', 'macos', 'tvos', 'watchos']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - run: ./scripts/ci-select-xcode.sh
       - name: Validate Podspec
         run: pod lib lint --verbose --platforms=${{ matrix.platform }}
@@ -57,5 +57,5 @@ jobs:
     name: No changes in high risk files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - run: ./scripts/no-changes-in-high-risk-files.sh

--- a/.github/workflows/profile-data-generator.yml
+++ b/.github/workflows/profile-data-generator.yml
@@ -10,13 +10,13 @@ jobs:
     name: Build app and test runner
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - run: ./scripts/ci-select-xcode.sh 13.4.1
       - name: Install SentryCli
         run: brew install getsentry/tools/sentry-cli
       - name: Cache Carthage dependencies
         id: trendingmovies-carthage-cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
         with:
           path: ./Samples/TrendingMovies/Carthage/Build
           key: trendingmovies-carthage-cache-key-${{ hashFiles('Samples/TrendingMovies/Cartfile.resolved') }}
@@ -25,7 +25,7 @@ jobs:
         run: cd Samples/TrendingMovies && carthage update --use-xcframeworks
       - name: Cache TrendingMovies App and dSYM build products
         id: cache-trending-movies-app
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
         with:
           path: |
             DerivedData/Build/Products/Debug-iphoneos/TrendingMovies.app
@@ -33,7 +33,7 @@ jobs:
           key: trendingmovies-app-cache-key-${{ hashFiles('Samples/TrendingMovies/TrendingMovies/**') }}
       - name: Cache ProfileDataGenerator UI Test Runner App build product
         id: cache-profiledatagenerator-test-runner-app
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
         with:
           path: |
             DerivedData/Build/Products/Debug-iphoneos/ProfileDataGeneratorUITest-Runner.app
@@ -62,7 +62,7 @@ jobs:
         run: |
           sentry-cli --auth-token ${{ secrets.SENTRY_AUTH_TOKEN }} upload-dif --org sentry-sdks --project trending-movies DerivedData/Build/Products/Debug-iphoneos/TrendingMovies.app.dSYM
       - name: Archiving DerivedData
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5  # v3
         with:
           name: data-generator-build-products
           path: |
@@ -79,8 +79,8 @@ jobs:
       matrix:
         suite: ['High-end device', 'Mid-range device']
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3
         with:
           name: data-generator-build-products
       - run: npm install -g saucectl@0.107.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Prepare release
-        uses: getsentry/action-prepare-release@v1
+        uses: getsentry/action-prepare-release@c8e1c2009ab08259029170132c384f03c1064c0e  # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     name: 'Release a new version'
     steps:
       - name: Check out current commit (${{ github.sha }})
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
         with:
           token: ${{ secrets.GH_RELEASE_PAT }}
           fetch-depth: 0

--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -32,14 +32,14 @@ jobs:
             xcode: '13.4.1'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - run: ./scripts/ci-select-xcode.sh ${{matrix.xcode}}
       - name: Install SentryCli
         run: brew install getsentry/tools/sentry-cli
       - run: git apply ./scripts/set-device-tests-environment.patch
       - name: Cache iOS-Swift App and dSYM build products
         id: ios-swift-cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
         with:
           path: |
             DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app.dSYM
@@ -47,7 +47,7 @@ jobs:
           key: ios-swift-for-ui-testing-cache-key-${{ hashFiles('Samples/iOS-Swift/iOS-Swift/**') }}-Xcode-${{ matrix.xcode }}
       - name: Cache iOS-Swift UI Test Runner App build product
         id: ios-swift-uitest-runner-cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
         with:
           path: |
             DerivedData/Build/Products/Debug-iphoneos/iOS-SwiftUITests-Runner.app
@@ -74,7 +74,7 @@ jobs:
         run: |
           sentry-cli --auth-token ${{ secrets.SENTRY_AUTH_TOKEN }} upload-dif --org sentry-sdks --project sentry-cocoa DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app.dSYM
       - name: Archiving DerivedData
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5  # v3
         with:
           name: DerivedData-Xcode-${{matrix.xcode}}
           path: |
@@ -108,9 +108,9 @@ jobs:
             suite: 'iOS-10'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3
         with:
           name: DerivedData-Xcode-${{matrix.xcode}}
 

--- a/.github/workflows/security-check.yaml
+++ b/.github/workflows/security-check.yaml
@@ -1,0 +1,8 @@
+name: Security Check
+on:
+  pull_request:
+
+jobs:
+  security-check:
+    uses: Buzzvil/workflows/.github/workflows/security-check.yaml@main
+    secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,10 @@ jobs:
     name: Build test server
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - name: Cache for Test Server
         id: cache_test_server
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
         with:
           path: ./test-server/.build
           key: test-server-${{ hashFiles('./test-server') }}
@@ -44,7 +44,7 @@ jobs:
         run: cp $(swift build --show-bin-path -c release)/Run test-server-exec
 
       - name: Archiving DerivedData
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5  # v3
         with:
           name: test-server
           path: |
@@ -127,8 +127,8 @@ jobs:
             test-destination-os: 'latest'
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3
         with:
           name: test-server
       - name: Allow test-server to run
@@ -161,7 +161,7 @@ jobs:
         run: ./scripts/xcode-test.sh ${{matrix.platform}} ${{matrix.test-destination-os}} ${{matrix.xcode}} $GITHUB_REF_NAME
 
       - name: Archiving DerivedData Logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5  # v3
         if: failure()
         with:
           name: derived-data-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
@@ -169,7 +169,7 @@ jobs:
             /Users/runner/Library/Developer/Xcode/DerivedData/**/Logs/**
 
       - name: Archiving Raw Test Logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5  # v3
         if: ${{  failure() || cancelled() }}
         with:
           name: raw-test-output-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
@@ -195,10 +195,10 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
 
       - name: Cache for Test Server
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
         id: cache_test_server
         with:
           path: ./test-server/.build
@@ -218,7 +218,7 @@ jobs:
         run: ./scripts/tests-with-thread-sanitizer.sh
 
       - name: Archiving Test Logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5  # v3
         with:
           path: thread-sanitizer.log
 
@@ -230,7 +230,7 @@ jobs:
         target: ['ios_swift', 'ios_objc', 'tvos_swift']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - run: ./scripts/ci-select-xcode.sh
 
       # GitHub Actions sometimes fail to launch the UI tests. Therefore we retry
@@ -255,7 +255,7 @@ jobs:
             device: 'iPhone 8 (14.5)'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - run: ./scripts/ci-select-xcode.sh ${{matrix.xcode}}
 
       # GitHub Actions sometimes fail to launch the UI tests. Therefore we retry
@@ -272,7 +272,7 @@ jobs:
         target: ['ios_swift', 'ios_objc', 'tvos_swift']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
 
       # GH action images don't have an iOS 12.4 simulator. Therefore we have to download and install the simulator manually.
       - name: Install iOS 12.4 simulator
@@ -291,7 +291,7 @@ jobs:
     runs-on: macos-12
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - run: ./scripts/ci-select-xcode.sh 13.4.1
 
       # GitHub Actions sometimes fail to launch the UI tests. Therefore we retry

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build and Upload iOS-Swift to Testflight
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - run: ./scripts/ci-select-xcode.sh
       - run: bundle install
 
@@ -45,7 +45,7 @@ jobs:
           bundle exec fastlane ios_swift_to_testflight
 
       - name: Archiving
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5  # v3
         with:
           name: dSYMs
           path: |


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to specific commit SHAs instead of mutable tags/branches to improve supply chain security.

### Changes

- `.github/workflows/benchmarking.yml`: pinned 1 action(s)
- `.github/workflows/release.yml`: pinned 1 action(s)

### Why?

Mutable references (`@v2`, `@main`) can be changed by upstream maintainers at any time. SHA pinning ensures reproducible builds and protects against supply chain attacks.

### References

- [GitHub Actions security hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
